### PR TITLE
Enlarged main header

### DIFF
--- a/gui/eventwindow.gui
+++ b/gui/eventwindow.gui
@@ -337,7 +337,7 @@
 		}
 	}
 
-	type newspaper_superevent_window = default_popup_two_lines {
+	type newspaper_superevent_window = default_popup {
 		datacontext = "[EventWindow.GetEvent]"
 
 		alpha = 0
@@ -351,16 +351,34 @@
 		blockoverride "header_close_button_visibility" {
 			visible = yes
 		}
+		blockoverride "header" {
+			widget = {
+				size = { 100% 82 }
+			
+				popup_top_header = {}
 
-
+				textbox = {
+					block "first_line_position" {
+						position = { 0 24 }
+					}
+					size = { 75% 40 }
+					block "window_header_name" {
+						text = ""
+					}
+					elide = right
+					fontsize_min = 14
+					parentanchor = hcenter
+					align = center|nobaseline
+					using = header_font
+					using = (fontsize = 32)
+					default_format = "#header"
+				}
+			}
+		}
 		blockoverride "window_header_name" {
 			raw_text = "#BOLD [EventWindow.GetTitle]#!"
 		}
 		blockoverride "content" {}
-
-		blockoverride "second_text" {
-			text = "EVENT_WINDOW_EVENT_LOCATION"
-		}
 
 		blockoverride "goto_visibility" {
 			visible = yes


### PR DESCRIPTION
The main header of the superevent pop has been enlarged
The second header has been removed.

Superevent window now looks like this:
![grafik](https://github.com/Bananamannl/Newspaper-Mod/assets/63145937/bf80921b-83d9-4a1d-a39c-10f8143ae992)


close #10 